### PR TITLE
修复 CustomItemSlot 在反序列化时产生重复实例

### DIFF
--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/ItemSlotRegistry.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/ItemSlotRegistry.kt
@@ -48,23 +48,26 @@ object ItemSlotRegistry : Initializable, KoinComponent {
 
     /**
      * 获取一个 `Equipment Slot Group` 对应的 [ItemSlot].
+     * 如果不存在, 则返回一个空集合.
      */
     fun get(group: EquipmentSlotGroup): Set<ItemSlot> {
-        return requireNotNull(vanillaByGroup[group]) { "Unknown slot for EquipmentSlotGroup: '$group'" }
+        return vanillaByGroup[group] ?: emptySet()
     }
 
     /**
      * 获取一个 `Equipment Slot` 对应的 [ItemSlot].
+     * 如果不存在, 则返回 `null`.
      */
-    fun get(slot: EquipmentSlot): ItemSlot {
-        return requireNotNull(vanillaBySlot[slot]) { "Unknown slot for EquipmentSlot: '$slot'" }
+    fun get(slot: EquipmentSlot): ItemSlot? {
+        return vanillaBySlot[slot]
     }
 
     /**
      * 获取一个跟 `Slot Number` 对应的 [ItemSlot].
+     * 如果不存在, 则返回 `null`.
      */
-    fun get(slotIndex: Int): ItemSlot {
-        return requireNotNull(custom[slotIndex]) { "Unknown slot for SlotIndex: '$slotIndex'" }
+    fun get(slotIndex: Int): ItemSlot? {
+        return custom[slotIndex]
     }
 
     /**


### PR DESCRIPTION
设计上对于任意 slotIndex 全局只有一个对应的实例, 但是之前的代码并没有很好的处理反序列化, 导致每次反序列化都会产生一个新的 ItemSlot 实例而不是复用现有的