### PR TITLE
实现物品耐久度相关的机制

### DIFF
--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/components/Damageable.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/components/Damageable.kt
@@ -30,7 +30,6 @@ data class Damageable(
      * 当前损耗.
      */
     val damage: Int,
-
     /**
      * 最大损耗.
      */
@@ -64,7 +63,7 @@ data class Damageable(
         override val id: String,
     ) : ItemComponentType<Damageable> {
         override fun read(holder: ItemComponentHolder): Damageable? {
-            val itemMeta = (holder.item.itemMeta as? CraftDamageable) ?: return null
+            val itemMeta = (holder.item.itemMeta as? CraftDamageable)?.takeIf { it.hasMaxDamage() } ?: return null
             return Damageable(
                 damage = itemMeta.damage,
                 maxDamage = itemMeta.maxDamage,

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/components/ItemMaxDamage.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/components/ItemMaxDamage.kt
@@ -24,7 +24,7 @@ interface ItemMaxDamage : Examinable {
         override val id: String,
     ) : ItemComponentType<Int> {
         override fun read(holder: ItemComponentHolder): Int? {
-            return (holder.item.itemMeta as? CraftDamageable)?.maxDamage
+            return (holder.item.itemMeta as? CraftDamageable)?.takeIf { it.hasMaxDamage() }?.maxDamage
         }
 
         override fun write(holder: ItemComponentHolder, value: Int) {

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/logic/ItemSlotChangeListener.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/logic/ItemSlotChangeListener.kt
@@ -112,6 +112,23 @@ internal abstract class ItemSlotChangeListener {
         return itemLevel <= playerLevel
     }
 
+    protected fun testDurability(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?): Boolean {
+        if (nekoStack == null) {
+            return true // 如果不是萌芽物品, 那么该物品应该按照游戏原版的逻辑处理
+        }
+
+        val damageableComponent = nekoStack.components.get(ItemComponentTypes.DAMAGEABLE)
+        if (damageableComponent == null) {
+            return true // 如果物品没有 damageable 组件, 那么物品则没有耐久度, 应该返回 true
+        }
+
+        if (damageableComponent.damage + 1 >= damageableComponent.maxDamage) {
+            return false // 如果物品已经损坏, 那么应该返回 false
+        }
+
+        return true
+    }
+
     ///
 
     /**

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/logic/ItemSlotChangeListeners.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/logic/ItemSlotChangeListeners.kt
@@ -37,7 +37,8 @@ import kotlin.collections.iterator
 internal object AttackSpeedItemSlotChangeListener : ItemSlotChangeListener() {
     override fun test(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?): Boolean {
         return testSlot(player, slot, itemStack, nekoStack) &&
-                testLevel(player, slot, itemStack, nekoStack)
+                testLevel(player, slot, itemStack, nekoStack) &&
+                testDurability(player, slot, itemStack, nekoStack)
     }
 
     override fun handlePreviousItem(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?) {
@@ -86,7 +87,8 @@ internal object AttackSpeedItemSlotChangeListener : ItemSlotChangeListener() {
 internal object AttributeItemSlotChangeListener : ItemSlotChangeListener() {
     override fun test(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?): Boolean {
         return testSlot(player, slot, itemStack, nekoStack) &&
-                testLevel(player, slot, itemStack, nekoStack)
+                testLevel(player, slot, itemStack, nekoStack) &&
+                testDurability(player, slot, itemStack, nekoStack)
     }
 
     override fun handlePreviousItem(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?) {
@@ -120,7 +122,8 @@ internal object EnchantmentItemSlotChangeListener : ItemSlotChangeListener() {
     // 唯一需要处理的就是监听物品栏发生的变化, 以应用附魔的效果.
 
     override fun test(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?): Boolean {
-        return testLevel(player, slot, itemStack, nekoStack)
+        return testLevel(player, slot, itemStack, nekoStack) &&
+                testDurability(player, slot, itemStack, nekoStack)
     }
 
     override fun handlePreviousItem(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?) {
@@ -159,7 +162,9 @@ internal object EnchantmentItemSlotChangeListener : ItemSlotChangeListener() {
  */
 internal object KizamiItemSlotChangeListener : ItemSlotChangeListener() {
     override fun test(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?): Boolean {
-        return testSlot(player, slot, itemStack, nekoStack) && testLevel(player, slot, itemStack, nekoStack)
+        return testSlot(player, slot, itemStack, nekoStack) &&
+                testLevel(player, slot, itemStack, nekoStack) &&
+                testDurability(player, slot, itemStack, nekoStack)
     }
 
     // 首先, 从玩家身上移除所有已有的铭刻效果.
@@ -214,7 +219,9 @@ internal object KizamiItemSlotChangeListener : ItemSlotChangeListener() {
  */
 internal object SkillItemSlotChangeListener : ItemSlotChangeListener() {
     override fun test(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?): Boolean {
-        return testSlot(player, slot, itemStack, nekoStack) && testLevel(player, slot, itemStack, nekoStack)
+        return testSlot(player, slot, itemStack, nekoStack) &&
+                testLevel(player, slot, itemStack, nekoStack) &&
+                testDurability(player, slot, itemStack, nekoStack)
     }
 
     override fun handlePreviousItem(player: Player, slot: ItemSlot, itemStack: ItemStack, nekoStack: NekoStack?) {


### PR DESCRIPTION
实现了耐久度相关的基本机制

- 拥有 `damageable` 物品行为的物品, 在掉耐久时永远掉固定的1点 (耐久附魔偶尔不掉耐久的机制依然生效, 不受影响)
- 如果物品配置文件里的 `damageable.disappear_when_broken` 设置为 `false`, 那么物品将不会在耐久度归0时消失, 而是保持1点
- 耐久度只剩1点的物品无法跟世界进行任何交互 (无法攻击, 左右键等等), 也不会提供任何诸如属性和铭刻的效果加成
- 纯原版物品不在这些机制考虑的范围内, 包括套了萌芽皮的原版物品, 因为它们不存在 `damageable` 物品行为