### PR TITLE
AttributeModifierMechanic 支持 Modifier 覆盖操作

### DIFF
--- a/wakame-ext/src/main/kotlin/cc/mewcraft/wakame/compatibility/mythicmobs/mechanic/AttributeModifierMechanic.kt
+++ b/wakame-ext/src/main/kotlin/cc/mewcraft/wakame/compatibility/mythicmobs/mechanic/AttributeModifierMechanic.kt
@@ -36,7 +36,7 @@ class AttributeModifierMechanic(
     private val amount: PlaceholderDouble = mlc.getPlaceholderDouble(arrayOf("amount", "amt", "a"), .0, *emptyArray())
     private val operation: AttributeModifier.Operation = mlc.getEnum(arrayOf("operation", "op"), AttributeModifier.Operation::class.java, AttributeModifier.Operation.ADD)
     private val duration: PlaceholderInt = mlc.getPlaceholderInteger(arrayOf("duration", "dur"), 0, *emptyArray())
-    private val replace: Boolean = mlc.getBoolean(arrayOf("replace", "r"), false)
+    private val replace: Boolean = mlc.getBoolean(arrayOf("replace", "r"), true)
 
     override fun cast(data: SkillMetadata): SkillResult {
         val targetEntity = data.caster.entity.bukkitEntity as? LivingEntity ?: return SkillResult.INVALID_TARGET


### PR DESCRIPTION
### 修改了一个 MythicMobs 技能

`nekoattributemodifier`

新增了 `replace` 参数

| Attribute | Aliases | Description | Default |
|-----------|---------|-------------|---------|
| attribute | attr | 属性的种类, 参考 [Attributes](https://github.com/Nyaadanbou/wakame/blob/main/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/attribute/Attributes.kt) | - |
| name | - | 属性修饰符的名称 | - |
| operation | op | 属性修饰符的操作 | ADD |
| duration | dur | 属性修饰符的持续 tick 数 | 0 |
| **replace** | r | 是否替换生物上有相同 name 的属性修饰符 | false |