### PR TITLE
支持禁止玩家在特定世界与村民交易

### DIFF
--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/adventure/translator/TranslatableMessages.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/adventure/translator/TranslatableMessages.kt
@@ -84,6 +84,7 @@ object TranslatableMessages {
     val MSG_HOLD_LAST_DAMAGE_DEFAULT_WHEN_CAUSE_DAMAGE = create("msg_hold_last_damage_default_when_cause_damage")
     val MSG_HOLD_LAST_DAMAGE_DEFAULT_WHEN_RECEIVE_DAMAGE = create("msg_hold_last_damage_default_when_receive_damage")
     val MSG_HOLD_LAST_DAMAGE_DEFAULT_WHEN_CONSUME = create("msg_hold_last_damage_default_when_consume")
+    val MSG_VILLAGER_TRADE_DISABLED_IN_THIS_WORLD = create("msg_villager_trade_disabled_in_this_world")
 
     private fun create(key: String): TranslatableComponent.Builder {
         return Component.translatable().key(key)

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/entity/villager/VillagerTradeDisabler.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/entity/villager/VillagerTradeDisabler.kt
@@ -1,0 +1,39 @@
+package cc.mewcraft.wakame.entity.villager
+
+import cc.mewcraft.wakame.adventure.translator.TranslatableMessages
+import cc.mewcraft.wakame.config.MAIN_CONFIG
+import cc.mewcraft.wakame.config.optionalEntry
+import cc.mewcraft.wakame.lifecycle.initializer.Init
+import cc.mewcraft.wakame.lifecycle.initializer.InitStage
+import cc.mewcraft.wakame.util.registerEvents
+import net.kyori.adventure.key.Key
+import org.bukkit.Sound
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEntityEvent
+import xyz.xenondevs.commons.provider.orElse
+
+@Init(
+    stage = InitStage.POST_WORLD,
+)
+object VillagerTradeDisabler : Listener {
+
+    init {
+        registerEvents()
+    }
+
+    private val DISABLED_WORLDS: Set<Key> by MAIN_CONFIG.optionalEntry<Set<Key>>("disable_villager_trade_in_worlds").orElse(setOf())
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    private fun on(event: PlayerInteractEntityEvent) {
+        val rightClicked = event.rightClicked
+        val rightClickedLocation = rightClicked.location
+        val worldKey = rightClickedLocation.world.key
+        if (worldKey in DISABLED_WORLDS) {
+            event.isCancelled = true
+            event.player.playSound(rightClicked, Sound.ENTITY_VILLAGER_NO, 1f, 1f)
+            event.player.sendMessage(TranslatableMessages.MSG_VILLAGER_TRADE_DISABLED_IN_THIS_WORLD)
+        }
+    }
+}

--- a/wakame-plugin/src/main/resources/configs/config.yml
+++ b/wakame-plugin/src/main/resources/configs/config.yml
@@ -40,6 +40,12 @@ world_weather_control_use_interval_ticks: 12000
 #   rarity: 根据物品的稀有度 (rarity) 计算
 enchant_slot_base_provider: rarity
 
+# 禁止玩家在以下世界中与村民进行交易
+disable_villager_trade_in_worlds:
+  - koish:eden
+  - koish:dune
+  - koish:hollow
+
 # 关于调试模式
 debug:
   # 调试模式信息记录控制

--- a/wakame-plugin/src/main/resources/lang/zh_CN.yml
+++ b/wakame-plugin/src/main/resources/lang/zh_CN.yml
@@ -78,6 +78,7 @@ msg_hold_last_damage_default_when_simple_attack: "<red>无法使用损坏的物�
 msg_hold_last_damage_default_when_cause_damage: "<red>无法使用损坏的物品."
 msg_hold_last_damage_default_when_receive_damage: "<red>无法使用损坏的物品."
 msg_hold_last_damage_default_when_consume: "<red>无法使用损坏的物品."
+msg_villager_trade_disabled_in_this_world: "<red>这个世界无法与村民交易."
 
 # 像这样制定一个数字的格式, '#' 是 Java 的 DecimalFormat 的语法
 msg_number_format: "This is a decimal number: <arg:0:'zh-CN':'#'>."


### PR DESCRIPTION
### 配置文件改动

`configs/config.yml`

```yaml
# 禁止玩家在以下世界中与村民进行交易
disable_villager_trade_in_worlds:
  - koish:eden
  - koish:dune
  - koish:hollow
```