### PR TITLE
新机制: 便携式传送锚

### DIFF
--- a/wakame-hooks/wakame-hook-huskhomes/src/main/kotlin/cc/mewcraft/wakame/hook/impl/HuskHomesHook.kt
+++ b/wakame-hooks/wakame-hook-huskhomes/src/main/kotlin/cc/mewcraft/wakame/hook/impl/HuskHomesHook.kt
@@ -1,12 +1,16 @@
 package cc.mewcraft.wakame.hook.impl
 
 import cc.mewcraft.wakame.integration.Hook
+import cc.mewcraft.wakame.integration.teleport.NetworkTeleport
 import cc.mewcraft.wakame.util.registerEvents
 
 @Hook(plugins = ["HuskHomes"])
 object HuskHomesHook {
 
     init {
+        // 注册事件监听器
         TpaBlockListener().registerEvents()
+        // 注册跨服务器传送实现
+        NetworkTeleport.setImplementation(HuskHomesNetworkTeleport())
     }
 }

--- a/wakame-hooks/wakame-hook-huskhomes/src/main/kotlin/cc/mewcraft/wakame/hook/impl/HuskHomesNetworkTeleport.kt
+++ b/wakame-hooks/wakame-hook-huskhomes/src/main/kotlin/cc/mewcraft/wakame/hook/impl/HuskHomesNetworkTeleport.kt
@@ -1,0 +1,44 @@
+package cc.mewcraft.wakame.hook.impl
+
+import cc.mewcraft.wakame.integration.teleport.NetworkTeleport
+import net.kyori.adventure.key.Key
+import net.william278.huskhomes.api.HuskHomesAPI
+import net.william278.huskhomes.position.Position
+import net.william278.huskhomes.position.World
+import net.william278.huskhomes.teleport.Teleport
+import org.bukkit.entity.Player
+import java.util.*
+
+class HuskHomesNetworkTeleport : NetworkTeleport {
+
+    private val api: HuskHomesAPI
+        get() = HuskHomesAPI.getInstance()
+
+    override fun server(): Result<String> {
+        return Result.success(api.server)
+    }
+
+    override fun execute(player: Player, server: String, world: Key, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit> {
+        val user = api.adaptUser(player)
+        val target = Position.at(x, y, z, yaw, pitch, World.from(world.value(), UUID.randomUUID()), server)
+        api.teleportBuilder()
+            .executor(user)
+            .teleporter(user)
+            .type(Teleport.Type.TELEPORT)
+            .target(target)
+            .buildAndComplete(false)
+        return Result.success(Unit)
+    }
+
+    override fun execute(player: Player, server: String, world: String, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit> {
+        val user = api.adaptUser(player)
+        val target = Position.at(x, y, z, yaw, pitch, World.from(world, UUID.randomUUID()), server)
+        api.teleportBuilder()
+            .executor(user)
+            .teleporter(user)
+            .type(Teleport.Type.TELEPORT)
+            .target(target)
+            .buildAndComplete(false)
+        return Result.success(Unit)
+    }
+}

--- a/wakame-hooks/wakame-hook-huskhomes/src/main/kotlin/cc/mewcraft/wakame/hook/impl/TpaBlockListener.kt
+++ b/wakame-hooks/wakame-hook-huskhomes/src/main/kotlin/cc/mewcraft/wakame/hook/impl/TpaBlockListener.kt
@@ -27,12 +27,10 @@ class TpaBlockListener : Listener {
         }
 
         val request = event.request
-
         val requestType = request.type
+
         val recipient = event.recipient
-        //val requesterPos = request.requesterPosition
         val recipientPos = recipient.position
-        //val requesterServer = requesterPos.server
         val recipientServer = recipientPos.server
 
         when (requestType) {

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/adventure/translator/TranslatableMessages.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/adventure/translator/TranslatableMessages.kt
@@ -109,6 +109,9 @@ object TranslatableMessages {
     val MSG_ERR_NOT_INSIDE_STRUCTURE = create("msg_err_not_inside_structure")
     val MSG_CHANNELING_STARTED = create("msg_channeling_started")
     val MSG_CHANNELING_STOPPED = create("msg_channeling_stopped")
+    val MSG_ERR_CANNOT_SAVE_NETWORK_POS_IN_CURRENT_SERVER = create("msg_err_cannot_save_network_pos_in_current_server")
+    val MSG_ERR_CANNOT_SAVE_NETWORK_POS_IN_CURRENT_DIMENSION = create("msg_err_cannot_save_network_pos_in_current_dimension")
+    val MSG_NETWORK_POS_SAVED = create("msg_network_pos_saved")
 
     private fun create(key: String): TranslatableComponent.Builder {
         return Component.translatable().key(key)

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/integration/teleport/NetworkTeleport.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/integration/teleport/NetworkTeleport.kt
@@ -1,0 +1,31 @@
+package cc.mewcraft.wakame.integration.teleport
+
+import net.kyori.adventure.key.Key
+import org.bukkit.entity.Player
+
+/**
+ * 该接口提供跨服务器传送玩家的功能.
+ */
+interface NetworkTeleport {
+
+    fun server(): Result<String>
+    fun execute(player: Player, server: String, world: Key, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit>
+    fun execute(player: Player, server: String, world: String, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit>
+
+    companion object Impl : NetworkTeleport {
+
+        private var implementation: NetworkTeleport = object : NetworkTeleport {
+            override fun server(): Result<String> = Result.failure(NotImplementedError())
+            override fun execute(player: Player, server: String, world: String, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit> = Result.failure(NotImplementedError())
+            override fun execute(player: Player, server: String, world: Key, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit> = Result.failure(NotImplementedError())
+        }
+
+        fun setImplementation(impl: NetworkTeleport) {
+            implementation = impl
+        }
+
+        override fun server(): Result<String> = implementation.server()
+        override fun execute(player: Player, server: String, world: String, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit> = implementation.execute(player, server, world, x, y, z, yaw, pitch)
+        override fun execute(player: Player, server: String, world: Key, x: Double, y: Double, z: Double, yaw: Float, pitch: Float): Result<Unit> = implementation.execute(player, server, world, x, y, z, yaw, pitch)
+    }
+}

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/ItemBehaviorTypes.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/ItemBehaviorTypes.kt
@@ -198,6 +198,12 @@ object ItemBehaviorTypes {
     @JvmField
     val DUNGEON_ENTRY = typeOf("dungeon_entry", DungeonEntry)
 
+    /**
+     * 物品具有该行为时, 可以使用以跨服务器传送玩家.
+     */
+    @JvmField
+    val TELEPORT_ANCHOR = typeOf("teleport_anchor", TeleportAnchor)
+
     // ------------
     // 方便函数
     // ------------

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/impl/TeleportAnchor.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/impl/TeleportAnchor.kt
@@ -1,0 +1,74 @@
+package cc.mewcraft.wakame.item.behavior.impl
+
+import cc.mewcraft.wakame.adventure.translator.TranslatableMessages
+import cc.mewcraft.wakame.integration.teleport.NetworkTeleport
+import cc.mewcraft.wakame.item.*
+import cc.mewcraft.wakame.item.behavior.*
+import cc.mewcraft.wakame.item.data.ItemDataTypes
+import cc.mewcraft.wakame.item.data.impl.NetworkPosition
+import cc.mewcraft.wakame.item.property.ItemPropTypes
+import io.papermc.paper.datacomponent.DataComponentTypes
+
+/**
+ * 传送锚. 基于 [HuskHomes](https://william278.net/docs/huskhomes/api-examples) 实现.
+ *
+ * ### 行为描述
+ *
+ * - 一开始这个物品是一张“白纸”, 没有记录任何 [NetworkPosition].
+ * - 对着空气右键, 会将玩家当前的 [NetworkPosition] 记录在物品上.
+ * - 一旦物品有了记录, 就变成了消耗品 (`minecraft:consumable`).
+ * - 此时如果消耗掉, 就会将玩家传送到物品上记录的 [NetworkPosition].
+ */
+object TeleportAnchor : ItemBehavior {
+
+    override fun handleConsume(context: ConsumeContext): BehaviorResult {
+        val player = context.player
+        if (!context.itemstack.hasProp(ItemPropTypes.TELEPORT_ANCHOR)) {
+            return BehaviorResult.PASS
+        }
+        val pos = context.itemstack.getData(ItemDataTypes.NETWORK_POSITION) ?: return BehaviorResult.FINISH_AND_CANCEL
+        val res = NetworkTeleport.execute(player, pos.server, pos.world, pos.x, pos.y, pos.z, pos.yaw, pos.pitch)
+        return if (res.isSuccess) {
+            BehaviorResult.FINISH
+        } else {
+            BehaviorResult.FINISH_AND_CANCEL
+        }
+    }
+
+    override fun handleUse(context: UseContext): InteractionResult {
+        val player = context.player
+        val itemstack = context.itemstack
+        val teleportAnchor = itemstack.getProp(ItemPropTypes.TELEPORT_ANCHOR) ?: return InteractionResult.PASS
+        if (itemstack.hasData(ItemDataTypes.NETWORK_POSITION)) {
+            return InteractionResult.PASS // 已经绑定过坐标 - 不重复绑定
+        }
+        if (player.isSneaking.not()) return InteractionResult.PASS // 为防止误触, 只有在潜行时才可绑定坐标
+        val server = NetworkTeleport.server().getOrNull() ?: return InteractionResult.FAIL_AND_CANCEL
+        val loc = player.location
+        val world = loc.world.name
+        if (server !in teleportAnchor.allowedServers) {
+            player.sendMessage(TranslatableMessages.MSG_ERR_CANNOT_SAVE_NETWORK_POS_IN_CURRENT_SERVER)
+            return InteractionResult.FAIL_AND_CANCEL
+        }
+        if (world !in teleportAnchor.allowedDimensions) {
+            player.sendMessage(TranslatableMessages.MSG_ERR_CANNOT_SAVE_NETWORK_POS_IN_CURRENT_DIMENSION)
+            return InteractionResult.FAIL_AND_CANCEL
+        }
+        itemstack.setData(
+            ItemDataTypes.NETWORK_POSITION,
+            NetworkPosition(
+                x = loc.x,
+                y = loc.y,
+                z = loc.z,
+                yaw = loc.yaw,
+                pitch = loc.pitch,
+                world = world,
+                server = server,
+            )
+        )
+        // 一旦绑定了坐标, 则变为可消耗品
+        itemstack.setData(DataComponentTypes.CONSUMABLE, teleportAnchor.buildConsumable())
+        player.sendActionBar(TranslatableMessages.MSG_NETWORK_POS_SAVED)
+        return InteractionResult.SUCCESS_AND_CANCEL
+    }
+}

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/data/ItemDataTypes.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/data/ItemDataTypes.kt
@@ -138,6 +138,12 @@ data object ItemDataTypes {
     @JvmField
     val BREW_RECIPE: ItemDataType<ItemBrewRecipe> = typeOf("brew_recipe")
 
+    /**
+     * 记录了一个网络中的坐标.
+     */
+    @JvmField
+    val NETWORK_POSITION: ItemDataType<NetworkPosition> = typeOf("network_position")
+
     // ------------
     // 方便函数
     // ------------

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/data/impl/NetworkPosition.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/data/impl/NetworkPosition.kt
@@ -1,0 +1,14 @@
+package cc.mewcraft.wakame.item.data.impl
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class NetworkPosition(
+    val x: Double,
+    val y: Double,
+    val z: Double,
+    val yaw: Float,
+    val pitch: Float,
+    val world: String,
+    val server: String,
+)

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/ItemPropTypes.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/ItemPropTypes.kt
@@ -452,6 +452,12 @@ data object ItemPropTypes {
     @JvmField
     val DUNGEON_ENTRY: ItemPropType<DungeonEntry> = typeOf("dungeon_entry")
 
+    /**
+     * 储存了 [cc.mewcraft.wakame.item.behavior.impl.TeleportAnchor] 行为的全局配置项.
+     */
+    @JvmField
+    val TELEPORT_ANCHOR: ItemPropType<TeleportAnchor> = typeOf("teleport_anchor")
+
     // ------------
     // 方便函数
     // ------------

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/impl/TeleportAnchor.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/impl/TeleportAnchor.kt
@@ -1,0 +1,33 @@
+package cc.mewcraft.wakame.item.property.impl
+
+import cc.mewcraft.wakame.util.adventure.BukkitSound
+import io.papermc.paper.datacomponent.item.Consumable
+import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation
+import net.kyori.adventure.key.Key
+import org.bukkit.Registry
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class TeleportAnchor(
+    val allowedServers: Set<String> = setOf(),
+    val allowedDimensions: Set<String> = setOf(),
+    val consumableData: ConsumableData = ConsumableData(),
+) {
+
+    fun buildConsumable(): Consumable {
+        return Consumable.consumable()
+            .animation(consumableData.animation)
+            .sound(consumableData.sound)
+            .consumeSeconds(consumableData.consumeSeconds)
+            .hasConsumeParticles(consumableData.hasConsumeParticles)
+            .build()
+    }
+
+    @ConfigSerializable
+    data class ConsumableData(
+        val consumeSeconds: Float = 3f,
+        val animation: ItemUseAnimation = ItemUseAnimation.BLOCK,
+        val sound: Key = Registry.SOUND_EVENT.getKeyOrThrow(BukkitSound.BLOCK_PORTAL_TRAVEL),
+        val hasConsumeParticles: Boolean = false,
+    )
+}

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/display/implementation/standard/Renderer.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/display/implementation/standard/Renderer.kt
@@ -114,6 +114,7 @@ internal object StandardItemRenderer : AbstractItemRenderer<Nothing>() {
         renderCoreContainer(collector, item.coreContainer)
         StandardRenderingHandlerRegistry.RARITY.process(collector, item.rarity2, item.getData(ItemDataTypes.REFORGE_HISTORY) ?: ReforgeHistory.ZERO)
         StandardRenderingHandlerRegistry.ENTITY_BUCKET_INFO.process(collector, item.getData(ItemDataTypes.ENTITY_BUCKET_INFO))
+        StandardRenderingHandlerRegistry.NETWORK_POSITION.process(collector, item.getData(ItemDataTypes.NETWORK_POSITION))
         StandardRenderingHandlerRegistry.ENCHANTMENTS.process(collector, item.getData(DataComponentTypes.ENCHANTMENTS))
         StandardRenderingHandlerRegistry.DAMAGE_RESISTANT.process(collector, if (item.hasData(DataComponentTypes.DAMAGE_RESISTANT)) Unit else null)
         StandardRenderingHandlerRegistry.FOOD.process(collector, item.getData(DataComponentTypes.FOOD))
@@ -297,4 +298,9 @@ internal object StandardRenderingHandlerRegistry : RenderingHandlerRegistry(Stan
 
     @JvmField
     val CASTABLE: RenderingHandler<Map<String, Castable>, CastableRendererFormat> = configure("castable") { data, format -> format.render(data) }
+
+    @JvmField
+    val NETWORK_POSITION: RenderingHandler<NetworkPosition, NetworkPositionRendererFormat> = configure("network_position") { data, format ->
+        format.render(data)
+    }
 }

--- a/wakame-plugin/src/main/resources/configs/renderer/standard/formats.yml
+++ b/wakame-plugin/src/main/resources/configs/renderer/standard/formats.yml
@@ -274,3 +274,35 @@ castable:
       jump: "<!i><light_purple>跳跃</light_purple>"
       sneak: "<!i><light_purple>潜行</light_purple>"
       sprint: "<!i><light_purple>冲刺</light_purple>"
+
+# id: `network_position`
+network_position:
+  namespace: special
+  # 位面翻译映射
+  server_map:
+    xhome1: "家园位面 #1"
+    xmine1: "冒险位面 #1"
+    xcaps1: "领域位面 #1"
+    xcity1: "主城位面 #1"
+  # 维度翻译映射
+  dimension_map:
+    home: "家园"
+    eden: "伊甸"
+    dune: "流沙"
+    hollow: "寒墟"
+    nether: "下界"
+    end: "末地"
+  # 可用标签
+  # <x> X 坐标
+  # <y> Y 坐标
+  # <z> Z 坐标
+  # <yaw> 朝向 Yaw
+  # <pitch> 朝向 Pitch
+  # <world> 世界名称
+  # <server> 位面名称
+  content:
+    - "<light_purple>该传送锚记录了一个坐标位置"
+    - "<light_purple>右键消耗可以传送到坐标位置"
+    - "<gray>坐标: <yellow>X:<x:zh-CN:#> Y:<y:zh-CN:#> Z:<z:zh-CN:#>"
+    - "<gray>维度: <yellow><world>"
+    - "<gray>位面: <yellow><server>"

--- a/wakame-plugin/src/main/resources/configs/renderer/standard/layout.yml
+++ b/wakame-plugin/src/main/resources/configs/renderer/standard/layout.yml
@@ -61,6 +61,7 @@ primary:
   - special:entity_bucket_info
   - special:fuel
   - special:castable
+  - special:network_position
 
   - (fixed:general)<st><dark_gray>             </dark_gray></st>
   - general:kizami

--- a/wakame-plugin/src/main/resources/lang/zh_CN.yml
+++ b/wakame-plugin/src/main/resources/lang/zh_CN.yml
@@ -103,6 +103,9 @@ msg_err_structure_not_found_in_chunk: "<red>当前区块没有结构: <arg:0>."
 msg_err_not_inside_structure: "<red>你不在结构空间内: <arg:0>"
 msg_channeling_started: "<gray>吟唱开始..."
 msg_channeling_stopped: "<gray>吟唱终止."
+msg_err_cannot_save_network_pos_in_current_server: "<red>无法在当前位面记录网络坐标."
+msg_err_cannot_save_network_pos_in_current_dimension: "<red>无法在当前维度记录网络坐标."
+msg_network_pos_saved: "<aqua>网络坐标已记录!"
 
 # 像这样制定一个数字的格式, '#' 是 Java 的 DecimalFormat 的语法
 msg_number_format: "This is a decimal number: <arg:0:'zh-CN':'#'>."


### PR DESCRIPTION
## TL; DR（来自源代码）

```kt
/**
 * 传送锚. 基于 [HuskHomes](https://william278.net/docs/huskhomes/api-examples) 实现.
 *
 * ### 行为描述
 *
 * - 一开始这个物品是一张“白纸”, 没有记录任何 [NetworkPosition].
 * - 对着空气右键, 会将玩家当前的 [NetworkPosition] 记录在物品上.
 * - 一旦物品有了记录, 就变成了消耗品 (`minecraft:consumable`).
 * - 此时如果消耗掉, 就会将玩家传送到物品上记录的 [NetworkPosition].
 */
```

https://github.com/user-attachments/assets/4c61e730-f674-4c6d-a951-7f44f3868a7d

## 新配置: `configs/renderer/standard/formats.yml`

```yaml
# id: `network_position`
network_position:
  namespace: special
  # 位面翻译映射
  server_map:
    xhome1: "家园位面 #1"
    xmine1: "冒险位面 #1"
    xcaps1: "领域位面 #1"
    xcity1: "主城位面 #1"
  # 维度翻译映射
  dimension_map:
    home: "家园"
    eden: "伊甸"
    dune: "流沙"
    hollow: "寒墟"
    nether: "下界"
    end: "末地"
  # 可用标签
  # <x> X 坐标
  # <y> Y 坐标
  # <z> Z 坐标
  # <yaw> 朝向 Yaw
  # <pitch> 朝向 Pitch
  # <world> 世界名称
  # <server> 位面名称
  content:
    - "<light_purple>该传送锚记录了一个坐标位置"
    - "<light_purple>右键消耗可以传送到坐标位置"
    - "<gray>坐标: <yellow>X:<x:zh-CN:#> Y:<y:zh-CN:#> Z:<z:zh-CN:#>"
    - "<gray>维度: <yellow><world>"
    - "<gray>位面: <yellow><server>"
```

## 新配置: `configs/renderer/strandard/layout.yml`

```yaml
primary:
  # ...
  - special:network_position
  # ...
```

## 新配置: `lang/`

```yaml
msg_err_cannot_save_network_pos_in_current_server: "<red>无法在当前位面记录网络坐标."
msg_err_cannot_save_network_pos_in_current_dimension: "<red>无法在当前维度记录网络坐标."
msg_network_pos_saved: "<aqua>网络坐标已记录!"
```

## 新配置: `configs/item/`

```yaml
# 定义物品外观
base: shulker_shell
clientbound/item_name: 便携式传送锚
clientbound/item_model: minecraft:structure_void

# 新配置项：teleport_anchor
teleport_anchor:
  allowed_servers:
    - "xcity1"
    - "xhome1"
  allowed_dimensions:
    - "eden"
  consumable_data:
    consume_seconds: 3.0
    animation: block
    sound: minecraft:block.portal.travel
    has_consume_particles: false
```