### PR TITLE
铭刻支持释放 MythicMobs 的机制

### DIFF
--- a/wakame-hooks/wakame-hook-betonquest/src/main/kotlin/cc/mewcraft/wakame/hook/impl/betonquest/BetonQuestHookDSL.kt
+++ b/wakame-hooks/wakame-hook-betonquest/src/main/kotlin/cc/mewcraft/wakame/hook/impl/betonquest/BetonQuestHookDSL.kt
@@ -8,6 +8,7 @@ import org.betonquest.betonquest.api.service.action.ActionRegistry
 import org.betonquest.betonquest.api.service.condition.ConditionRegistry
 import org.betonquest.betonquest.api.service.item.ItemRegistry
 import org.betonquest.betonquest.api.service.objective.ObjectiveRegistry
+import org.betonquest.betonquest.kernel.registry.feature.ScheduleRegistry
 import org.betonquest.betonquest.schedule.ActionScheduling
 
 fun hook(builder: BetonQuestHookDSL.() -> Unit) {
@@ -36,6 +37,8 @@ class BetonQuestHookDSL {
     }
 
     fun schedules(builder: FeatureRegistry<ActionScheduling.ScheduleType<*, *>>.() -> Unit) {
-        builder(pl.coreQuestTypeHandler.scheduleRegistry)
+        val componentLoader = pl.componentLoader
+        val scheduleRegistry = componentLoader.get(ScheduleRegistry::class.java)
+        builder(scheduleRegistry)
     }
 }

--- a/wakame-hooks/wakame-hook-mythicmobs/src/main/kotlin/cc/mewcraft/wakame/hook/impl/mythicmobs/MythicSkillIntegration.kt
+++ b/wakame-hooks/wakame-hook-mythicmobs/src/main/kotlin/cc/mewcraft/wakame/hook/impl/mythicmobs/MythicSkillIntegration.kt
@@ -17,7 +17,7 @@ object MythicSkillIntegration : SkillIntegration {
     private val mythicApi: MythicBukkit
         get() = MythicBukkit.inst()
 
-    override fun castBlockSkill(player: Player, id: String, ctx: Castable) {
+    override fun castBlockSkill(player: Player, id: String, ctx: Castable?) {
         val origin = player.location
         val entityTargets = listOf(MythicUtil.getTargetedEntity(player))
         val locationTargets = listOf(player.getLineOfSight(null, 32).last().location)
@@ -25,7 +25,7 @@ object MythicSkillIntegration : SkillIntegration {
         LOGGER.info("Trying to running block skill: $id")
     }
 
-    override fun castInlineSkill(player: Player, line: String, ctx: Castable) {
+    override fun castInlineSkill(player: Player, line: String, ctx: Castable?) {
         val line = "[ - $line ]"
         val entity: AbstractEntity = BukkitAdapter.adapt(player)
         val caster = mythicApi.skillManager.getCaster(entity)
@@ -41,7 +41,7 @@ object MythicSkillIntegration : SkillIntegration {
         }
     }
 
-    override fun isCooldown(player: Player, id: String, ctx: Castable): Boolean {
+    override fun isCooldown(player: Player, id: String, ctx: Castable?): Boolean {
         val skill = mythicApi.skillManager.getSkill(id).getOrNull() ?: return false
         val caster = mythicApi.skillManager.getCaster(BukkitAdapter.adapt(player))
         return skill.onCooldown(caster)

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/integration/skill/SkillIntegration.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/integration/skill/SkillIntegration.kt
@@ -11,7 +11,7 @@ interface SkillIntegration {
      * @param player 施放技能的玩家
      * @param id 技能的唯一标识, 格式取决于实现
      */
-    fun castBlockSkill(player: Player, id: String, ctx: Castable)
+    fun castBlockSkill(player: Player, id: String, ctx: Castable? = null)
 
     /**
      * 施放 [line] 对应的技能.
@@ -19,7 +19,7 @@ interface SkillIntegration {
      * @param player 施放技能的玩家
      * @param line 技能的内联配置, 格式取决于实现
      */
-    fun castInlineSkill(player: Player, line: String, ctx: Castable)
+    fun castInlineSkill(player: Player, line: String, ctx: Castable? = null)
 
     /**
      * 检查玩家 [player] 的技能 [id] 是否处于冷却中.
@@ -28,7 +28,7 @@ interface SkillIntegration {
      * @param id 需要检查的技能的唯一标识, 格式取决于实现
      * @return 如果技能处于冷却中则返回 true, 否则返回 false
      */
-    fun isCooldown(player: Player, id: String, ctx: Castable): Boolean
+    fun isCooldown(player: Player, id: String, ctx: Castable? = null): Boolean
 
     /**
      * This companion object holds current [SkillIntegration] implementation.
@@ -36,9 +36,9 @@ interface SkillIntegration {
     companion object : SkillIntegration {
 
         private val NO_OP: SkillIntegration = object : SkillIntegration {
-            override fun castBlockSkill(player: Player, id: String, ctx: Castable) = Unit
-            override fun castInlineSkill(player: Player, line: String, ctx: Castable) = Unit
-            override fun isCooldown(player: Player, id: String, ctx: Castable): Boolean = false
+            override fun castBlockSkill(player: Player, id: String, ctx: Castable?) = Unit
+            override fun castInlineSkill(player: Player, line: String, ctx: Castable?) = Unit
+            override fun isCooldown(player: Player, id: String, ctx: Castable?): Boolean = false
         }
 
         private var implementation: SkillIntegration = NO_OP
@@ -47,15 +47,15 @@ interface SkillIntegration {
             implementation = impl
         }
 
-        override fun castBlockSkill(player: Player, id: String, ctx: Castable) {
+        override fun castBlockSkill(player: Player, id: String, ctx: Castable?) {
             return implementation.castBlockSkill(player, id, ctx)
         }
 
-        override fun castInlineSkill(player: Player, line: String, ctx: Castable) {
+        override fun castInlineSkill(player: Player, line: String, ctx: Castable?) {
             return implementation.castInlineSkill(player, line, ctx)
         }
 
-        override fun isCooldown(player: Player, id: String, ctx: Castable): Boolean {
+        override fun isCooldown(player: Player, id: String, ctx: Castable?): Boolean {
             return implementation.isCooldown(player, id, ctx)
         }
     }

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/integration/skill/SkillWrapper.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/integration/skill/SkillWrapper.kt
@@ -30,7 +30,7 @@ interface SkillWrapper {
      *
      * @param player 释放者
      */
-    fun cast(player: Player, ctx: Castable)
+    fun cast(player: Player, ctx: Castable? = null)
 
     /**
      * 一个完整的机制, 以 [id] 唯一识别.
@@ -45,7 +45,7 @@ interface SkillWrapper {
         override val type: SkillWrapperType
             get() = SkillWrapperTypes.BLOCK
 
-        override fun cast(player: Player, ctx: Castable) {
+        override fun cast(player: Player, ctx: Castable?) {
             SkillIntegration.castBlockSkill(player, id, ctx)
         }
     }
@@ -63,7 +63,7 @@ interface SkillWrapper {
         override val type: SkillWrapperType
             get() = SkillWrapperTypes.INLINE
 
-        override fun cast(player: Player, ctx: Castable) {
+        override fun cast(player: Player, ctx: Castable?) {
             SkillIntegration.castInlineSkill(player, line, ctx)
         }
     }

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/kizami/KizamiEffectSkill.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/kizami/KizamiEffectSkill.kt
@@ -1,0 +1,23 @@
+package cc.mewcraft.wakame.kizami
+
+import cc.mewcraft.wakame.integration.skill.SkillWrapper
+import org.bukkit.entity.Player
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Setting
+
+@ConfigSerializable
+data class KizamiEffectSkill(
+    @Setting("on_apply")
+    val skillOnApply: SkillWrapper,
+    @Setting("on_remove")
+    val skillOnRemove: SkillWrapper,
+) : KizamiEffect {
+
+    override fun apply(player: Player) {
+        skillOnApply.cast(player)
+    }
+
+    override fun remove(player: Player) {
+        skillOnRemove.cast(player)
+    }
+}

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/kizami/KizamiRegistryLoader.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/kizami/KizamiRegistryLoader.kt
@@ -1,9 +1,11 @@
 package cc.mewcraft.wakame.kizami
 
 import cc.mewcraft.lazyconfig.configurate.register
+import cc.mewcraft.lazyconfig.configurate.registerExact
 import cc.mewcraft.lazyconfig.configurate.serializer.DispatchingSerializer
 import cc.mewcraft.wakame.LOGGER
 import cc.mewcraft.wakame.entity.attribute.AttributeFacadeRegistryLoader
+import cc.mewcraft.wakame.integration.skill.SkillWrapper
 import cc.mewcraft.wakame.lifecycle.initializer.Init
 import cc.mewcraft.wakame.lifecycle.initializer.InitFun
 import cc.mewcraft.wakame.lifecycle.initializer.InitStage
@@ -51,11 +53,12 @@ internal object KizamiRegistryLoader : RegistryLoader {
             withDefaults()
             serializers {
                 register<KizamiEffectAttributeModifier>(KizamiEffectAttributeModifier.SERIALIZER)
-                register(
+                registerAll(SkillWrapper.serializers())
+                registerExact<KizamiEffect>(
                     DispatchingSerializer.createPartial<String, KizamiEffect>(
                         mapOf(
                             "attribute_modifier" to KizamiEffectAttributeModifier::class,
-                            // TODO 支持技能
+                            "skill_execution" to KizamiEffectSkill::class,
                         )
                     )
                 )
@@ -72,7 +75,7 @@ internal object KizamiRegistryLoader : RegistryLoader {
                 registryAction(entryId, entryVal)
             } catch (e: Throwable) {
                 IdePauser.pauseInIde(e)
-                LOGGER.error("Failed to register kizami from file: ${f.relativeTo(rootDirectory)}")
+                LOGGER.error("Failed to register kizami from file: ${f.relativeTo(rootDirectory)}", e)
             }
         }
     }

--- a/wakame-plugin/src/main/resources/configs/kizami/entries/example.yml
+++ b/wakame-plugin/src/main/resources/configs/kizami/entries/example.yml
@@ -11,10 +11,10 @@ styles: "<green>"
 # map value 类型为 list, 是本铭刻数量对应的效果.
 #
 # 下面这个例子中:
-# 拥有 1 个铭刻提供 +5 universal_defense,
-# 拥有 2 个铭刻提供 +10 universal_defense,
-# 拥有 3 个铭刻提供 +15 universal_defense 和 +0.1 knockback_resistance
-# 拥有 4 个铭刻提供 +20 universal_defense 和 +0.2 knockback_resistance
+# 拥有 1 个铭刻提供 +5 universal_defense 属性
+# 拥有 2 个铭刻提供 +10 universal_defense 属性
+# 拥有 3 个铭刻提供 +15 universal_defense 属性, +0.1 knockback_resistance 属性
+# 拥有 4 个铭刻提供 +20 universal_defense 属性, +0.2 knockback_resistance 属性, 执行相关技能
 effects:
   1:
     - { type: "attribute_modifier", id: "universal_defense", operation: add, value: 5 }
@@ -26,3 +26,6 @@ effects:
   4:
     - { type: "attribute_modifier", id: "universal_defense", operation: add, value: 20 }
     - { type: "attribute_modifier", id: "knockback_resistance", operation: add, value: 0.2 }
+    - type: "skill_execution"
+      on_apply: { type: "block", value: "on_apply_skill" }  # on_apply 会在刻印数量满足的那一刻执行一次
+      on_remove: { type: "block", value: "on_remove_skill" }  # on_remove 会在刻印数量不满足的那一刻执行一次


### PR DESCRIPTION
## 配置文件改动：`configs/kizami/entries/`
```yaml
# 该铭刻的展示名字
name: "<green>庇护"

# 该铭刻的展示风格
styles: "<green>"

# 该铭刻提供的效果
#
# 该 node 的 value 是一个 map, 其中
# map key 类型为 int, 是本铭刻在玩家身上的数量,
# map value 类型为 list, 是本铭刻数量对应的效果.
#
# 下面这个例子中:
# 拥有 1 个铭刻提供 +5 universal_defense 属性
# 拥有 2 个铭刻提供 +10 universal_defense 属性
# 拥有 3 个铭刻提供 +15 universal_defense 属性, +0.1 knockback_resistance 属性
# 拥有 4 个铭刻提供 +20 universal_defense 属性, +0.2 knockback_resistance 属性, 执行相关技能
effects:
  1:
    - { type: "attribute_modifier", id: "universal_defense", operation: add, value: 5 }
  2:
    - { type: "attribute_modifier", id: "universal_defense", operation: add, value: 10 }
  3:
    - { type: "attribute_modifier", id: "universal_defense", operation: add, value: 15 }
    - { type: "attribute_modifier", id: "knockback_resistance", operation: add, value: 0.1 }
  4:
    - { type: "attribute_modifier", id: "universal_defense", operation: add, value: 20 }
    - { type: "attribute_modifier", id: "knockback_resistance", operation: add, value: 0.2 }
    
    # 本 PR 新增的配置选项在这里
    - type: "skill_execution"
      on_apply: { type: "block", value: "on_apply_skill" }  # on_apply 会在刻印数量满足的那一刻执行一次
      on_remove: { type: "block", value: "on_remove_skill" }  # on_remove 会在刻印数量不满足的那一刻执行一次

```