### PR TITLE
新物品行为: `virtual_book`

### DIFF
--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/ItemBehaviorTypes.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/ItemBehaviorTypes.kt
@@ -240,6 +240,12 @@ object ItemBehaviorTypes {
     @JvmField
     val SETS_RETROACTIVE_CARD = typeOf("sets_retroactive_card", SetsRetroactionCard)
 
+    /**
+     * 物品具有该行为时, 右键使用将为玩家打开一本虚拟书.
+     */
+    @JvmField
+    val VIRTUAL_BOOK = typeOf("virtual_book", VirtualBook)
+
     // ------------
     // 方便函数
     // ------------

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/impl/VirtualBook.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/behavior/impl/VirtualBook.kt
@@ -1,0 +1,19 @@
+package cc.mewcraft.wakame.item.behavior.impl
+
+import cc.mewcraft.wakame.item.behavior.InteractionResult
+import cc.mewcraft.wakame.item.behavior.UseContext
+import cc.mewcraft.wakame.item.getProp
+import cc.mewcraft.wakame.item.property.ItemPropTypes
+
+object VirtualBook : SimpleInteract {
+
+    override fun handleSimpleUse(context: UseContext): InteractionResult {
+        val itemstack = context.itemstack
+        val virtualBook = itemstack.getProp(ItemPropTypes.VIRTUAL_BOOK)
+            ?: return InteractionResult.PASS
+        val book = virtualBook.createAdventureBook()
+        val player = context.player
+        player.openBook(book)
+        return InteractionResult.SUCCESS
+    }
+}

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/ItemPropTypes.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/ItemPropTypes.kt
@@ -527,6 +527,12 @@ data object ItemPropTypes {
     @JvmField
     val SETS_RETROACTIVE_CARD: ItemPropType<SetsRetroactiveCard> = typeOf("sets_retroactive_card")
 
+    /**
+     * 储存了 [cc.mewcraft.wakame.item.behavior.impl.VirtualBook] 行为的全局配置项.
+     */
+    @JvmField
+    val VIRTUAL_BOOK: ItemPropType<VirtualBook> = typeOf("virtual_book")
+
     // ------------
     // 方便函数
     // ------------

--- a/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/impl/VirtualBook.kt
+++ b/wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/impl/VirtualBook.kt
@@ -1,0 +1,16 @@
+package cc.mewcraft.wakame.item.property.impl
+
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.Component
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class VirtualBook(
+    val title: Component,
+    val author: Component,
+    val pages: List<Component>,
+) {
+    fun createAdventureBook(): Book {
+        return Book.book(title, author, pages)
+    }
+}

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/network/ItemStackRenderer.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/network/ItemStackRenderer.kt
@@ -67,6 +67,13 @@ object ItemStackRenderer : PacketListener {
     }
 
     @PacketHandler
+    private fun handleSetPlayerInventory(event: ClientboundSetPlayerInventoryPacketEvent) {
+        val player = event.player
+        if (isCreative(player)) return
+        event.contents = event.contents.copy().modify(player)
+    }
+
+    @PacketHandler
     private fun handleUpdateAdvancements(event: ClientboundUpdateAdvancementsPacketEvent) {
         val player = event.player
         val added = event.added.map { holder ->

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/network/event/PacketEventManager.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/network/event/PacketEventManager.kt
@@ -57,6 +57,7 @@ object PacketEventManager {
         registerPlayerEventType(::ClientboundUpdateMobEffectPacketEvent)
         registerPlayerEventType(::ClientboundUpdateAdvancementsPacketEvent)
         registerPlayerEventType(::ClientboundBlockEntityDataPacketEvent)
+        registerPlayerEventType(::ClientboundSetPlayerInventoryPacketEvent)
 
         // serverbound - player
         registerPlayerEventType(::ServerboundPlaceRecipePacketEvent)

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/network/event/clientbound/ClientboundSetPlayerInventoryPacketEvent.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/network/event/clientbound/ClientboundSetPlayerInventoryPacketEvent.kt
@@ -1,0 +1,27 @@
+package cc.mewcraft.wakame.network.event.clientbound
+
+import cc.mewcraft.wakame.network.event.PlayerPacketEvent
+import net.minecraft.network.protocol.game.ClientboundSetPlayerInventoryPacket
+import org.bukkit.entity.Player
+
+class ClientboundSetPlayerInventoryPacketEvent(
+    player: Player,
+    packet: ClientboundSetPlayerInventoryPacket,
+) : PlayerPacketEvent<ClientboundSetPlayerInventoryPacket>(player, packet) {
+
+    var slot = packet.slot
+        set(value) {
+            field = value
+            changed = true
+        }
+
+    var contents = packet.contents
+        set(value) {
+            field = value
+            changed = true
+        }
+
+    override fun buildChangedPacket(): ClientboundSetPlayerInventoryPacket {
+        return ClientboundSetPlayerInventoryPacket(slot, contents)
+    }
+}


### PR DESCRIPTION
## TL;DR

现在可以创建内容实时更新的书了！

## 新物品配置项：`virtual_book`

```yaml
base: shulker_shell
clientbound/item_model: minecraft:book
clientbound/item_name: "虚拟书"
virtual_book:
  title: "虚拟书"
  author: "上古时代"
  pages:
    - |-
      第一页。

      <hover:show_text:"I''m a tooltip">Hover here to see a tooltip</hover:show_text>

      <hover:show_text:"Run the command "/examplecommand""><click:run_command:/examplecommand>Click here to run a command<reset>
      
      <click:open_url:"https://www.spigotmc.org/resources/45604/">Click here to open a link</click>
    - |-
      第二页。

      <red>Example placeholders</red>
```