### PR TITLE
Koish 魔法值属性与 AuraSkills 魔法值系统联动

### DIFF
--- a/wakame-hooks/wakame-hook-auraskills/README.md
+++ b/wakame-hooks/wakame-hook-auraskills/README.md
@@ -53,6 +53,14 @@ traits:
     name: 生命值再生
   koish/attribute_lifesteal:
     name: 生命偷取
+  koish/attribute_manasteal:
+    name: 魔法偷取
+  koish/attribute_mana_consumption_rate:
+    name: 魔法消耗率
+  koish/attribute_mana_regeneration:
+    name: 魔法再生
+  koish/attribute_max_mana:
+    name: 最大魔法值
   koish/attribute_negative_critical_strike_power:
     name: 负暴击伤害
   koish/attribute_none_critical_strike_power:
@@ -121,6 +129,14 @@ templates:
       koish/attribute_health_regeneration:
         material: gray_dye
       koish/attribute_lifesteal:
+        material: gray_dye
+      koish/attribute_manasteal:
+        material: gray_dye
+      koish/attribute_mana_consumption_rate:
+        material: gray_dye
+      koish/attribute_mana_regeneration:
+        material: gray_dye
+      koish/attribute_max_mana:
         material: gray_dye
       koish/attribute_negative_critical_strike_power:
         material: gray_dye

--- a/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/AuraSkillsHook.kt
+++ b/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/AuraSkillsHook.kt
@@ -7,6 +7,7 @@ import cc.mewcraft.wakame.adventure.translator.TranslatableMessages
 import cc.mewcraft.wakame.entity.player.PlayerDataLoadingCoordinator
 import cc.mewcraft.wakame.entity.player.ResourceLoadingFixHandler
 import cc.mewcraft.wakame.integration.Hook
+import cc.mewcraft.wakame.integration.auraskills.ManaTraitBridge
 import cc.mewcraft.wakame.integration.playerlevel.PlayerLevelIntegration
 import cc.mewcraft.wakame.integration.playerlevel.PlayerLevelType
 import cc.mewcraft.wakame.integration.playermana.PlayerManaIntegration
@@ -42,6 +43,8 @@ object AuraSkillsHook : PlayerManaIntegration by AuraPlayerManaIntegration {
         registerTraitHandlers()
 
         AuraSkillsListener().registerEvents()
+
+        ManaTraitBridge.setImplementation(AuraSkillsManaTraitBridge)
     }
 
     private fun registerTraits() {
@@ -69,6 +72,10 @@ object AuraSkillsHook : PlayerManaIntegration by AuraPlayerManaIntegration {
         koishRegistry.registerTrait(KoishTraits.HAMMER_DAMAGE_RATIO)
         koishRegistry.registerTrait(KoishTraits.HEALTH_REGENERATION)
         koishRegistry.registerTrait(KoishTraits.LIFESTEAL)
+        koishRegistry.registerTrait(KoishTraits.MANASTEAL)
+        koishRegistry.registerTrait(KoishTraits.MANA_CONSUMPTION_RATE)
+        koishRegistry.registerTrait(KoishTraits.MANA_REGENERATION)
+        koishRegistry.registerTrait(KoishTraits.MAX_MANA)
         koishRegistry.registerTrait(KoishTraits.NEGATIVE_CRITICAL_STRIKE_POWER)
         koishRegistry.registerTrait(KoishTraits.NONE_CRITICAL_STRIKE_POWER)
         koishRegistry.registerTrait(KoishTraits.UNIVERSAL_DEFENSE)

--- a/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/AuraSkillsManaTraitBridge.kt
+++ b/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/AuraSkillsManaTraitBridge.kt
@@ -15,28 +15,11 @@ object AuraSkillsManaTraitBridge : ManaTraitBridge {
 
     override fun onTickUser(user: KoishUser, player: Player) {
         val auraUser = AuraSkillsApi.get().getUser(player.uniqueId)
-        //val itemSlotChanges = user.itemSlotChanges
         val attributeContainer = user.attributeContainer
         if (Bukkit.getCurrentTick() % 20 != 0) {
             return
         }
-        auraUser.removeTraitModifier(MODIFIER_MANA_REGEN)
-        auraUser.removeTraitModifier(MODIFIER_MAX_MANA)
         auraUser.addTraitModifier(TraitModifier(MODIFIER_MANA_REGEN, Traits.MANA_REGEN, attributeContainer.getValue(Attributes.MANA_REGENERATION)))
         auraUser.addTraitModifier(TraitModifier(MODIFIER_MAX_MANA, Traits.MAX_MANA, attributeContainer.getValue(Attributes.MAX_MANA)))
-        //itemSlotChanges.forEachChangingEntry { slot, curr, prev ->
-        //    if (prev != null && ItemStackEffectiveness.testSlot(slot, prev)) {
-        //        auraUser.removeTraitModifier(MODIFIER_MANA_REGEN)
-        //        auraUser.removeTraitModifier(MODIFIER_MAX_MANA)
-        //    }
-        //    if (curr != null &&
-        //        ItemStackEffectiveness.testSlot(slot, curr) &&
-        //        ItemStackEffectiveness.testLevel(player, curr) &&
-        //        ItemStackEffectiveness.testDamaged(curr)
-        //    ) {
-        //        auraUser.addTraitModifier(TraitModifier(MODIFIER_MANA_REGEN, Traits.MANA_REGEN, attributeContainer.getValue(Attributes.MANA_REGENERATION)))
-        //        auraUser.addTraitModifier(TraitModifier(MODIFIER_MAX_MANA, Traits.MAX_MANA, attributeContainer.getValue(Attributes.MAX_MANA)))
-        //    }
-        //}
     }
 }

--- a/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/AuraSkillsManaTraitBridge.kt
+++ b/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/AuraSkillsManaTraitBridge.kt
@@ -1,0 +1,42 @@
+package cc.mewcraft.wakame.hook.impl.auraskills
+
+import cc.mewcraft.wakame.entity.attribute.Attributes
+import cc.mewcraft.wakame.integration.auraskills.ManaTraitBridge
+import dev.aurelium.auraskills.api.AuraSkillsApi
+import dev.aurelium.auraskills.api.trait.TraitModifier
+import dev.aurelium.auraskills.api.trait.Traits
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import cc.mewcraft.wakame.entity.player.User as KoishUser
+
+object AuraSkillsManaTraitBridge : ManaTraitBridge {
+    private const val MODIFIER_MANA_REGEN = "koish_attribute_mana_regen"
+    private const val MODIFIER_MAX_MANA = "koish_attribute_max_mana"
+
+    override fun onTickUser(user: KoishUser, player: Player) {
+        val auraUser = AuraSkillsApi.get().getUser(player.uniqueId)
+        //val itemSlotChanges = user.itemSlotChanges
+        val attributeContainer = user.attributeContainer
+        if (Bukkit.getCurrentTick() % 20 != 0) {
+            return
+        }
+        auraUser.removeTraitModifier(MODIFIER_MANA_REGEN)
+        auraUser.removeTraitModifier(MODIFIER_MAX_MANA)
+        auraUser.addTraitModifier(TraitModifier(MODIFIER_MANA_REGEN, Traits.MANA_REGEN, attributeContainer.getValue(Attributes.MANA_REGENERATION)))
+        auraUser.addTraitModifier(TraitModifier(MODIFIER_MAX_MANA, Traits.MAX_MANA, attributeContainer.getValue(Attributes.MAX_MANA)))
+        //itemSlotChanges.forEachChangingEntry { slot, curr, prev ->
+        //    if (prev != null && ItemStackEffectiveness.testSlot(slot, prev)) {
+        //        auraUser.removeTraitModifier(MODIFIER_MANA_REGEN)
+        //        auraUser.removeTraitModifier(MODIFIER_MAX_MANA)
+        //    }
+        //    if (curr != null &&
+        //        ItemStackEffectiveness.testSlot(slot, curr) &&
+        //        ItemStackEffectiveness.testLevel(player, curr) &&
+        //        ItemStackEffectiveness.testDamaged(curr)
+        //    ) {
+        //        auraUser.addTraitModifier(TraitModifier(MODIFIER_MANA_REGEN, Traits.MANA_REGEN, attributeContainer.getValue(Attributes.MANA_REGENERATION)))
+        //        auraUser.addTraitModifier(TraitModifier(MODIFIER_MAX_MANA, Traits.MAX_MANA, attributeContainer.getValue(Attributes.MAX_MANA)))
+        //    }
+        //}
+    }
+}

--- a/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/KoishAttributeTrait.kt
+++ b/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/KoishAttributeTrait.kt
@@ -20,9 +20,7 @@ import org.bukkit.event.player.PlayerChangedWorldEvent
  * 用于处理 Koish 的所有 Attribute Trait.
  */
 class KoishAttributeTrait : Listener, BukkitTraitHandler {
-
     companion object {
-
         private val TRAIT_TO_ATTRIBUTE: Map<Trait, Attribute> = hashMapOf(
             KoishTraits.ATTACK_KNOCKBACK to Attributes.ATTACK_KNOCKBACK,
             KoishTraits.BLOCK_INTERACTION_RANGE to Attributes.BLOCK_INTERACTION_RANGE,
@@ -45,6 +43,12 @@ class KoishAttributeTrait : Listener, BukkitTraitHandler {
             KoishTraits.HAMMER_DAMAGE_RATIO to Attributes.HAMMER_DAMAGE_RATIO,
             KoishTraits.HEALTH_REGENERATION to Attributes.HEALTH_REGENERATION,
             KoishTraits.LIFESTEAL to Attributes.LIFESTEAL,
+            KoishTraits.MANASTEAL to Attributes.MANASTEAL,
+            //region 特殊处理魔法值
+            KoishTraits.MANA_CONSUMPTION_RATE to Attributes.MANA_CONSUMPTION_RATE,
+            KoishTraits.MANA_REGENERATION to Attributes.MANA_REGENERATION,
+            KoishTraits.MAX_MANA to Attributes.MAX_MANA,
+            //endregion
             KoishTraits.NEGATIVE_CRITICAL_STRIKE_POWER to Attributes.NEGATIVE_CRITICAL_STRIKE_POWER,
             KoishTraits.NONE_CRITICAL_STRIKE_POWER to Attributes.NONE_CRITICAL_STRIKE_POWER,
             KoishTraits.UNIVERSAL_DEFENSE to Attributes.UNIVERSAL_DEFENSE,
@@ -54,7 +58,12 @@ class KoishAttributeTrait : Listener, BukkitTraitHandler {
             KoishTraits.UNIVERSAL_MIN_ATTACK_DAMAGE to Attributes.UNIVERSAL_MIN_ATTACK_DAMAGE,
         )
 
-        private val ATTRIBUTE_TO_MODIFIER_KEY: HashMap<Attribute, Key> = HashMap<Attribute, Key>()
+        private val ATTRIBUTE_TO_MODIFIER_KEY: HashMap<Attribute, Key> = HashMap()
+        private fun getModifierKeyBy(attribute: Attribute): Key {
+            return ATTRIBUTE_TO_MODIFIER_KEY.computeIfAbsent(attribute) { attribute ->
+                Key.key("koish", "auraskills/trait/${attribute.id}")
+            }
+        }
     }
 
     override fun getBaseLevel(player: Player, trait: Trait): Double {
@@ -96,12 +105,6 @@ class KoishAttributeTrait : Listener, BukkitTraitHandler {
             val player = event.player
             val user = AuraSkillsApi.get().getUser(player.uniqueId)
             set(player, user, trait)
-        }
-    }
-
-    private fun getModifierKeyBy(attribute: Attribute): Key {
-        return ATTRIBUTE_TO_MODIFIER_KEY.computeIfAbsent(attribute) { attribute ->
-            Key.key("koish", "auraskills/trait/${attribute.id}")
         }
     }
 

--- a/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/KoishTraits.kt
+++ b/wakame-hooks/wakame-hook-auraskills/src/main/kotlin/cc/mewcraft/wakame/hook/impl/auraskills/KoishTraits.kt
@@ -4,8 +4,6 @@ import dev.aurelium.auraskills.api.registry.NamespacedId
 import dev.aurelium.auraskills.api.trait.CustomTrait
 
 object KoishTraits {
-
-
     private val KOISH_ATTRIBUTE_TRAITS = ArrayList<CustomTrait>()
 
     // 使用懒加载. 按照目前的实现, 读取这个 property 时, KOISH_ATTRIBUTE_TRAITS 应该已经初始化完了.
@@ -197,6 +195,42 @@ object KoishTraits {
         CustomTrait
             .builder(NamespacedId.of("koish", "attribute_lifesteal"))
             //.displayName("Lifesteal")
+            .build()
+    )
+
+    @JvmField
+    val MANASTEAL: CustomTrait = register(
+        TraitType.ATTRIBUTE,
+        CustomTrait
+            .builder(NamespacedId.of("koish", "attribute_manasteal"))
+            //.displayName("Manasteal")
+            .build()
+    )
+
+    @JvmField
+    val MANA_CONSUMPTION_RATE: CustomTrait = register(
+        TraitType.ATTRIBUTE,
+        CustomTrait
+            .builder(NamespacedId.of("koish", "attribute_mana_consumption_rate"))
+            //.displayName("Mana Consumption Rate")
+            .build()
+    )
+
+    @JvmField
+    val MANA_REGENERATION: CustomTrait = register(
+        TraitType.ATTRIBUTE,
+        CustomTrait
+            .builder(NamespacedId.of("koish", "attribute_mana_regeneration"))
+            //.displayName("Mana Regeneration")
+            .build()
+    )
+
+    @JvmField
+    val MAX_MANA: CustomTrait = register(
+        TraitType.ATTRIBUTE,
+        CustomTrait
+            .builder(NamespacedId.of("koish", "attribute_max_mana"))
+            //.displayName("Max Mana")
             .build()
     )
 

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/catalog/enchantment/CatalogEnchantmentInitializer.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/catalog/enchantment/CatalogEnchantmentInitializer.kt
@@ -1,0 +1,4 @@
+package cc.mewcraft.wakame.catalog.enchantment
+
+object CatalogEnchantmentInitializer {
+}

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/entity/player/ServerOnlineUserTicker.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/entity/player/ServerOnlineUserTicker.kt
@@ -3,6 +3,7 @@ package cc.mewcraft.wakame.entity.player
 import cc.mewcraft.wakame.enchantment.system.EnchantmentAttributeSystem
 import cc.mewcraft.wakame.enchantment.system.EnchantmentEffectSystem
 import cc.mewcraft.wakame.entity.attribute.system.ItemAttributeSystem
+import cc.mewcraft.wakame.integration.auraskills.ManaTraitBridge
 import cc.mewcraft.wakame.item.ItemBehaviorListener
 import cc.mewcraft.wakame.item.ScanItemSlotChanges
 import cc.mewcraft.wakame.item.behavior.impl.weapon.KatanaSwitchSystem
@@ -30,6 +31,7 @@ object ServerOnlineUserTicker : Listener {
             KatanaTickSystem.onTickUser(user, player)
             KatanaSwitchSystem.onTickUser(user, player)
             SequenceComboFeature.onTickUser(user, player)
+            ManaTraitBridge.onTickUser(user, player)
         }
     }
 }

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/integration/auraskills/ManaTraitBridge.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/integration/auraskills/ManaTraitBridge.kt
@@ -4,6 +4,12 @@ import cc.mewcraft.wakame.entity.player.OnlineUserTicker
 import cc.mewcraft.wakame.entity.player.User
 import org.bukkit.entity.Player
 
+/**
+ * 使 Koish 的魔法值属性:
+ * - [cc.mewcraft.wakame.entity.attribute.Attributes.MAX_MANA]
+ * - [cc.mewcraft.wakame.entity.attribute.Attributes.MANA_REGENERATION]
+ * 与 AuraSkills 的魔法值系统相关联.
+ */
 interface ManaTraitBridge : OnlineUserTicker {
     companion object Impl : ManaTraitBridge {
         private var implementation: ManaTraitBridge = object : ManaTraitBridge {}

--- a/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/integration/auraskills/ManaTraitBridge.kt
+++ b/wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/integration/auraskills/ManaTraitBridge.kt
@@ -1,0 +1,19 @@
+package cc.mewcraft.wakame.integration.auraskills
+
+import cc.mewcraft.wakame.entity.player.OnlineUserTicker
+import cc.mewcraft.wakame.entity.player.User
+import org.bukkit.entity.Player
+
+interface ManaTraitBridge : OnlineUserTicker {
+    companion object Impl : ManaTraitBridge {
+        private var implementation: ManaTraitBridge = object : ManaTraitBridge {}
+
+        fun setImplementation(impl: ManaTraitBridge) {
+            implementation = impl
+        }
+
+        override fun onTickUser(user: User, player: Player) {
+            implementation.onTickUser(user, player)
+        }
+    }
+}


### PR DESCRIPTION
## 改动总结

### 用户侧 / 配置文件侧变动（重点）

在 `Koish/configs/hook/auraskills/stats.yml` 的 `traits` 段下，新增 4 个 Trait 开关：

```yaml
traits:
  koish/attribute_manasteal:
    enabled: true
  koish/attribute_mana_consumption_rate:
    enabled: true
  koish/attribute_mana_regeneration:
    enabled: true
  koish/attribute_max_mana:
    enabled: true
```

在 `AuraSkills/message_xxx.yml` 的 `traits` 段下，新增 4 个 Trait 名字翻译：

```yaml
traits:
  koish/attribute_manasteal:
    name: 魔法偷取
  koish/attribute_mana_consumption_rate:
    name: 魔法消耗率
  koish/attribute_mana_regeneration:
    name: 魔法再生
  koish/attribute_max_mana:
    name: 最大魔法值
```

在 `AuraSkills/menus/stat_info.yml` 的 `templates.trait.contexts` 段下，新增 4 个 Trait 图标模板：

```yaml
templates:
  trait:
    contexts:
      koish/attribute_manasteal:
        material: gray_dye
      koish/attribute_mana_consumption_rate:
        material: gray_dye
      koish/attribute_mana_regeneration:
        material: gray_dye
      koish/attribute_max_mana:
        material: gray_dye
```

---

### 程序侧变动（简略）

- 新增 `ManaTraitBridge` 接口（Bridge 委托模式），将 Koish 的 `MAX_MANA`、`MANA_REGENERATION` 属性值每 20 tick（1 秒）同步写入 AuraSkills 的 `TraitModifier`，驱动 AuraSkills 魔法值系统。
- 在 `KoishTraits` 中注册 4 个新 Trait：`MANASTEAL`、`MANA_CONSUMPTION_RATE`、`MANA_REGENERATION`、`MAX_MANA`。
- 将上述 4 个 Trait 加入 `KoishAttributeTrait` 的属性映射表，走标准 Trait → Attribute 同步流程（`MANASTEAL`、`MANA_CONSUMPTION_RATE` 也随属性变化实时同步）。
- 在 `ServerOnlineUserTicker` 的每 tick 循环中接入 `ManaTraitBridge`。