### PR TITLE
调整 Mechanic: `koish_damage_attribute_map` 支持从 parent 链获取属性

### DIFF
--- a/.github/skills/mythicmobs-hook-pr/SKILL.md
+++ b/.github/skills/mythicmobs-hook-pr/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: mythicmobs-hook-pr
+description: >
+  Guide for writing pull request descriptions when adding or modifying
+  MythicMobs Mechanic, Condition, ItemDrop, or Placeholder in the
+  wakame-hook-mythicmobs module. Use this skill when creating PRs for
+  the mythicmobs hook, or when asked to document MythicMobs integration
+  changes, mechanic parameters, condition parameters, drops, or placeholders.
+---
+
+# MythicMobs Hook PR 书写规范
+
+本技能规范了在 `wakame-hooks/wakame-hook-mythicmobs` 模块中添加或修改 Mechanic、Condition、ItemDrop、Placeholder 时，PR 描述应遵循的格式。
+
+---
+
+## 1. 总体结构
+
+PR 描述按变更类型分节，每种类型使用 `##` 标题。节的排列顺序：
+
+1. 改名（如有）
+2. 调整已有功能（如有）
+3. 全新功能
+
+每节标题格式：
+
+|场景|标题格式|
+|---|---|
+|批量改名|`## Mechanic 改名` / `## Condition 改名` / `## ItemDrop 改名`|
+|调整已有功能|`## 调整 Mechanic: \`koish_xxx\`` / `## 调整 Condition: \`koish_xxx\``|
+|全新功能|`## 全新 Mechanic: \`koish_xxx\`` / `## 全新 Condition: \`koish_xxx\``|
+
+---
+
+## 2. 改名节
+
+当批量重命名 mechanic/condition/drop 时，使用列表格式：
+
+```markdown
+## Mechanic 改名
+
+为平滑迁移，原名字依然能使用，但尽快迁移到新名字以避免未来可能存在的冲突
+
+- `old_name` -> `new_name`
+- `old_name2` -> `new_name2`
+```
+
+---
+
+## 3. Mechanic / Condition 参数表
+
+每个 Mechanic / Condition 的参数**必须**用 Markdown 表格描述。表格列：
+
+|列|说明|
+|---|---|
+|名字|参数的主名字（MythicMobs 配置中使用的 key）|
+|别名|参数的简写别名|
+|类型|参数类型（见下方类型词汇表）|
+|默认|默认值|
+|说明|参数的功能描述|
+
+### 3.1 模板
+
+````markdown
+## 全新 Mechanic: `koish_example`
+
+简要描述该 mechanic 的用途。
+
+### 参数
+
+|名字|别名|类型|默认|说明|
+|---|---|---|---|---|
+|`param_name`|`pn`|占位符双精度浮点数|`1.0`|参数的功能描述|
+|`flag`|`f`|布尔值|`false`|是否启用某功能|
+
+### 使用示例
+
+```yaml
+Skills:
+- koish_example{pn=0.5;f=true} @target ~onAttack
+```
+````
+
+### 3.2 调整已有功能的模板
+
+当为已有 Mechanic / Condition 增加新参数时，将参数分为"新增参数"和"已有参数"两个表格：
+
+````markdown
+## 调整 Mechanic: `koish_example`
+
+简要描述变更内容。
+
+### 新增参数
+
+|名字|别名|类型|默认|说明|
+|---|---|---|---|---|
+|`new_param`|`np`|枚举 (`A`, `B`)|`A`|新增参数的说明|
+
+### 已有参数
+
+|名字|别名|类型|默认|说明|
+|---|---|---|---|---|
+|`old_param`|`op`|布尔值|`false`|已有参数的说明|
+````
+
+---
+
+## 4. Placeholder 节
+
+Placeholder 不使用参数表格，而是描述其功能和用法：
+
+````markdown
+## 全新占位符: `<koish.xxx>`
+
+返回某个数值的描述。
+
+### 参数
+
+|名字|类型|说明|
+|---|---|---|
+|`arg1`|字符串|参数说明|
+
+### 示例
+
+```yaml
+- message{m="Value: <koish.xxx.arg1>"} @self
+```
+````
+
+---
+
+## 5. ItemDrop 节
+
+````markdown
+## 全新 ItemDrop: `koish_xxx`
+
+简要描述该 drop 的用途。
+
+### 参数
+
+|名字|别名|类型|默认|说明|
+|---|---|---|---|---|
+|`param`|`p`|字符串|无|参数说明|
+````
+
+---
+
+## 6. 设计说明节（可选）
+
+当 PR 涉及较复杂的设计决策时，在参数表格之后添加 `### 设计说明` 小节，用要点列表描述关键设计：
+
+```markdown
+### 设计说明
+
+- **伤害归属不变**：DamageSource 始终基于 caster
+- **递归查找**：通过 MythicBukkit API 沿 parent 链递归解析
+- **错误处理**：链中断时输出精确到层级的 warn 日志
+```
+
+---
+
+## 7. 类型词汇表
+
+在参数表的"类型"列中，使用以下统一术语：
+
+|术语|对应 MythicMobs API|
+|---|---|
+|布尔值|`mlc.getBoolean`|
+|整数|`mlc.getInteger`|
+|浮点数|`mlc.getFloat`|
+|双精度浮点数|`mlc.getDouble`|
+|字符串|`mlc.getString`|
+|占位符整数|`mlc.getPlaceholderInteger` / `PlaceholderInt`|
+|占位符双精度浮点数|`mlc.getPlaceholderDouble` / `PlaceholderDouble`|
+|枚举 (`值1`, `值2`, ...)|`mlc.getEnum`|
+|范围双精度浮点数|`RangedDouble`|
+|字符串列表|`mlc.getStringList`|
+
+---
+
+## 8. 完整示例
+
+以下是一个完整的 PR 描述示例：
+
+````markdown
+## 调整 Mechanic: `koish_damage_attribute_map`
+
+新增属性来源配置，支持从施法者的 parent（召唤者）链获取属性来计算伤害。
+
+### 新增参数
+
+|名字|别名|类型|默认|说明|
+|---|---|---|---|---|
+|`source`|`src`|枚举 (`CASTER`, `PARENT`)|`CASTER`|属性来源。`CASTER` 使用施法者自身属性，`PARENT` 使用施法者的 parent 属性|
+|`source_depth`|`sd`|整数 (1~8)|`1`|当 `source=PARENT` 时，沿 parent 链向上查找的层数|
+
+### 已有参数
+
+|名字|别名|类型|默认|说明|
+|---|---|---|---|---|
+|`percent`|`p`|占位符双精度浮点数|`1.0`|最终伤害数值占面板数值的百分比|
+|`ignore_blocking`|`ib`|布尔值|`false`|是否无视格挡|
+|`ignore_resistance`|`ir`|布尔值|`false`|是否无视抗性提升|
+|`ignore_absorption`|`ia`|布尔值|`false`|是否无视伤害吸收|
+|`knockback`|`kb`|布尔值|`true`|是否造成击退效果|
+
+### 使用示例
+
+```yaml
+# 使用施法者自身属性 (默认)
+Skills:
+- koish_damage_attribute_map{p=0.8} @target ~onAttack
+
+# 使用施法者的 parent 的属性
+Skills:
+- koish_damage_attribute_map{source=PARENT;p=1.0} @target ~onAttack
+
+# 使用往上2层 parent 的属性
+Skills:
+- koish_damage_attribute_map{src=PARENT;sd=2} @target ~onAttack
+```
+
+### 设计说明
+
+- **伤害归属不变**：DamageSource 始终基于 caster（施法者），只有属性来源可切换
+- **递归查找 parent 链**：通过 `MythicBukkit.inst().mobManager.getActiveMob()` 递归解析
+- **错误处理**：链中任何一层断裂都会输出精确到层级的 warn 日志
+````
+
+---
+
+## 9. 注意事项
+
+1. **表格用最小格式**：不要加多余空格对齐列（遵循项目 Markdown 规范）
+2. **MythicMobs 配置中的名字用 snake_case**：新增的 mechanic/condition 统一使用 `koish_` 前缀
+3. **使用示例必须包含 YAML 代码块**：展示实际的 MythicMobs 技能配置
+4. **改名兼容性说明**：如果旧名字仍然可用，需要在改名节中明确说明
+5. **注册点**：新增的 mechanic/condition/drop 需要在 `ConfigListener.kt` 的对应 `when` 分支中注册
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,28 +6,49 @@
 
 ## 模块职责划分: wakame-mixin vs wakame-plugin
 
-`wakame-mixin` 定义**接口和数据结构**，`wakame-plugin` 提供**实现和运行时逻辑**。
+`wakame-mixin` 是 **NMS Mixin 模块**，包含 Java Mixin 类 (NMS 补丁) 和 Kotlin bridge 接口 (NMS 级别的抽象)。使用 Horizon (`io.canvasmc.horizon`) + Weaver (`io.canvasmc.weaver.userdev`) 构建。**不包含任何游戏逻辑或物品系统代码。**
 
-当 wakame-plugin 需要向 wakame-mixin 中的代码注入行为时，使用 **接口委托模式**：
-- 在 `wakame-mixin` 中定义 `fun interface` 或普通 `interface`
-- 在 `wakame-mixin` 的调用方持有一个 `var handler: MyHandler? = null`
-- 在 `wakame-plugin` 中实现该接口，并在 `init {}` 块中注入: `CallerObject.handler = this`
+`wakame-plugin` 包含**所有游戏逻辑**：接口、数据结构、实现、配置读取、事件监听、tick 系统等。ItemBehavior、ItemProp、CastableTrigger、OnlineUserTicker、@Init 等核心抽象全部在此模块中。
 
-**示例** (组合键序列):
+### wakame-mixin Bridge 模式 (跨模块)
+
+当 Mixin 类 (NMS 层) 需要调用插件逻辑时，使用 **Bridge 委托模式**：
+- 在 `wakame-mixin/bridge/` 中定义 `interface`，带有 `companion object Impl` 委托到 `var implementation`
+- Mixin 类直接调用 companion object
+- `wakame-plugin` 通过 `setImplementation()` 注入实现
+
 ```kotlin
-// wakame-mixin: 定义接口
+// wakame-mixin/bridge/DamageManagerBridge.kt
+interface DamageManagerBridge {
+    companion object Impl : DamageManagerBridge {
+        private var implementation: DamageManagerBridge = object : DamageManagerBridge { /* 默认抛异常 */ }
+        fun setImplementation(impl: DamageManagerBridge) { implementation = impl }
+        override fun injectDamageLogic(...) = implementation.injectDamageLogic(...)
+    }
+    fun injectDamageLogic(event: EntityDamageEvent, originalLastHurt: Float, isDuringInvulnerable: Boolean): Float
+}
+```
+
+关键 Bridge 接口: `KoishItemBridge` (物品系统)、`DamageManagerBridge` (伤害系统)、`MythicMobsBridge` 等。
+
+### 模块内解耦模式 (wakame-plugin 内部)
+
+当 `wakame-plugin` 内部需要解耦不同特性时，使用 **handler 注入模式**：
+- 在调用方持有 `var handler: MyHandler? = null`
+- 在实现方的 `init {}` 块中注入
+
+```kotlin
+// 定义接口 (wakame-plugin/item/behavior/impl/SequenceComboHandler.kt)
 fun interface SequenceComboHandler {
     fun handleInput(player: Player, castableMap: Map<String, CastableProp>, input: GenericCastableTrigger)
 }
 
-// wakame-mixin: 调用方
+// 调用方 (wakame-plugin/item/behavior/impl/Castable.kt)
 object Castable : SimpleInteract {
     var sequenceComboHandler: SequenceComboHandler? = null
-    // 在 handleSimpleUse/handleSimpleAttack 中调用:
-    // sequenceComboHandler?.handleInput(player, castable, trigger)
 }
 
-// wakame-plugin: 实现并注入
+// 实现并注入 (wakame-plugin/item/feature/SequenceComboFeature.kt)
 @Init(InitStage.POST_WORLD)
 object SequenceComboFeature : SequenceComboHandler {
     init { CastableBehavior.sequenceComboHandler = this }
@@ -39,15 +60,15 @@ object SequenceComboFeature : SequenceComboHandler {
 
 ## ItemProp 范式
 
-`ItemProp` 是附加在物品类型上的静态数据，定义在 `wakame-mixin` 中。
+`ItemProp` 是附加在物品类型上的静态数据，定义在 `wakame-plugin` 中。
 
 ### 定义新的 ItemProp 数据类型
 
-在 `wakame-mixin/src/main/kotlin/cc/mewcraft/wakame/item/property/impl/` 下创建 `data class`，标记 `@ConfigSerializable`。
+在 `wakame-plugin/src/main/kotlin/cc/mewcraft/wakame/item/property/impl/` 下创建 `data class`，标记 `@ConfigSerializable`。
 
 ### 注册到 ItemPropTypes
 
-在 `wakame-mixin/.../item/property/ItemPropTypes.kt` 中添加:
+在 `wakame-plugin/.../item/property/ItemPropTypes.kt` 中添加:
 ```kotlin
 @JvmField
 val MY_PROP: ItemPropType<MyPropData> = typeOf("my_prop") {
@@ -68,11 +89,11 @@ val propValue = itemStack.getProp(ItemPropTypes.MY_PROP) ?: return
 
 ## ItemBehavior 范式
 
-`ItemBehavior` 描述物品与世界交互的逻辑，不含数据，定义在 `wakame-mixin` 中。
+`ItemBehavior` 描述物品与世界交互的逻辑，不含数据，定义在 `wakame-plugin` 中。
 
 ### 定义新的 ItemBehavior
 
-- 在 `wakame-mixin/.../item/behavior/impl/` 下创建 `object`，实现 `SimpleInteract`（或 `ItemBehavior`）。
+- 在 `wakame-plugin/.../item/behavior/impl/` 下创建 `object`，实现 `SimpleInteract`（或 `ItemBehavior`）。
   - 子目录按类别组织: `weapon/` (武器行为), `external/` (依赖外部插件的行为), `test/` (测试用)
   - 对应的 property impl 也使用相同子目录: `item/property/impl/weapon/`
 - `SimpleInteract` 将 6 种交互统一为 `handleSimpleUse` (右键) 和 `handleSimpleAttack` (左键) 两个入口。
@@ -215,7 +236,7 @@ object MyFeature {
 ## OnlineUserTicker 范式
 
 需要每 tick 对每个在线玩家执行逻辑时:
-- 实现 `OnlineUserTicker` 接口 (`wakame-mixin/.../entity/player/ticker.kt`)
+- 实现 `OnlineUserTicker` 接口 (`wakame-plugin/.../entity/player/ticker.kt`)
 - 在 `ServerOnlineUserTicker` (`wakame-plugin`) 中注册调用
 
 ```kotlin

--- a/wakame-hooks/wakame-hook-mythicmobs/src/main/kotlin/cc/mewcraft/wakame/hook/impl/mythicmobs/mechanic/DamageAttributeMapMechanic.kt
+++ b/wakame-hooks/wakame-hook-mythicmobs/src/main/kotlin/cc/mewcraft/wakame/hook/impl/mythicmobs/mechanic/DamageAttributeMapMechanic.kt
@@ -12,11 +12,14 @@ import io.lumine.mythic.api.skills.SkillMetadata
 import io.lumine.mythic.api.skills.SkillResult
 import io.lumine.mythic.api.skills.ThreadSafetyLevel
 import io.lumine.mythic.api.skills.placeholders.PlaceholderDouble
+import io.lumine.mythic.bukkit.MythicBukkit
+import io.lumine.mythic.core.mobs.ActiveMob
 import io.lumine.mythic.core.skills.SkillExecutor
 import io.lumine.mythic.core.skills.SkillMechanic
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import java.io.File
+import kotlin.jvm.optionals.getOrNull
 
 class DamageAttributeMapMechanic(
     manager: SkillExecutor,
@@ -29,10 +32,28 @@ class DamageAttributeMapMechanic(
         private val logger = LOGGER.decorate(DamageAttributeMapMechanic::class)
     }
 
-    init {
-        threadSafetyLevel = ThreadSafetyLevel.SYNC_ONLY
+    /**
+     * 属性来源. 决定从哪个实体获取属性来计算伤害.
+     */
+    private enum class AttributeSource {
+        /** 使用施法者自身的属性. */
+        CASTER,
+
+        /** 使用施法者的 parent (召唤者) 的属性. */
+        PARENT,
     }
 
+    /**
+     * 属性来源. 决定使用哪个实体的属性来计算伤害.
+     * - `CASTER` (默认): 使用施法者自身的属性.
+     * - `PARENT`: 使用施法者的 parent (召唤者) 的属性.
+     */
+    private val attributeSource: AttributeSource = mlc.getEnum(arrayOf("source", "src"), AttributeSource::class.java, AttributeSource.CASTER)
+    /**
+     * 当 [attributeSource] 为 [AttributeSource.PARENT] 时, 沿 parent 链向上查找的层数.
+     * `1` 表示直接 parent, `2` 表示 parent 的 parent, 以此类推. 默认 `1`, 最大 `3`.
+     */
+    private val sourceDepth: Int = mlc.getInteger(arrayOf("source_depth", "sd"), 1).coerceIn(1, 8)
     /**
      * 用于控制最终伤害数值占面板数值的百分比. `1.0` 为 100%, 以此类推. 默认 `1.0`.
      */
@@ -54,21 +75,91 @@ class DamageAttributeMapMechanic(
      */
     private val knockback: Boolean = mlc.getBoolean(arrayOf("knockback", "kb"), true)
 
+    init {
+        threadSafetyLevel = ThreadSafetyLevel.SYNC_ONLY
+    }
+
+    /**
+     * 根据 [attributeSource] 配置, 从 [SkillMetadata] 中解析出用于计算伤害的源实体.
+     *
+     * @return 源 [LivingEntity], 或 `null` 表示无法解析
+     */
+    private fun resolveSourceEntity(data: SkillMetadata): LivingEntity? {
+        return when (attributeSource) {
+            AttributeSource.CASTER -> {
+                data.caster?.entity?.bukkitEntity as? LivingEntity
+            }
+
+            AttributeSource.PARENT -> {
+                val casterMob = data.caster as? ActiveMob ?: run {
+                    logger.warn("Caster is not an ActiveMob, cannot resolve parent")
+                    return null
+                }
+                resolveNthParent(casterMob, sourceDepth, currentDepth = 1)
+            }
+        }
+    }
+
+    /**
+     * 递归沿 parent 链向上查找第 [targetDepth] 层的 parent 实体.
+     *
+     * @param mob 当前层的 [ActiveMob]
+     * @param targetDepth 目标深度 (总共要往上几层)
+     * @param currentDepth 当前已到达的深度 (从 1 开始)
+     * @return 目标层的 [LivingEntity], 或 `null` 表示链中断
+     */
+    private fun resolveNthParent(mob: ActiveMob, targetDepth: Int, currentDepth: Int): LivingEntity? {
+        val parentEntity = mob.parent.orElse(null) ?: run {
+            logger.warn("Cannot resolve parent at depth $currentDepth/$targetDepth: no parent found")
+            return null
+        }
+        val parentLiving = parentEntity.bukkitEntity as? LivingEntity ?: run {
+            logger.warn("Parent at depth $currentDepth/$targetDepth is not a LivingEntity")
+            return null
+        }
+        // 已到达目标深度, 返回结果
+        if (currentDepth >= targetDepth) {
+            return parentLiving
+        }
+        // 还需继续往上, 中间层的 parent 必须也是 ActiveMob
+        val parentMob = asActiveMob(parentEntity) ?: run {
+            logger.warn("Parent at depth $currentDepth/$targetDepth is not an ActiveMob, cannot traverse further")
+            return null
+        }
+        return resolveNthParent(parentMob, targetDepth, currentDepth + 1)
+    }
+
+    /**
+     * 尝试将 [AbstractEntity] 解析为 [ActiveMob].
+     */
+    private fun asActiveMob(entity: AbstractEntity): ActiveMob? {
+        return MythicBukkit.inst().mobManager.getActiveMob(entity.uniqueId).getOrNull()
+    }
+
     override fun castAtEntity(data: SkillMetadata, target: AbstractEntity): SkillResult {
         if (target.isDead) {
             return SkillResult.INVALID_TARGET
         }
         val targetEntity = target.bukkitEntity as? LivingEntity ?: return SkillResult.INVALID_TARGET
+
+        // 获取施法者实体 (用于 DamageSource, 即伤害归属)
         val casterEntity = data.caster?.entity?.bukkitEntity as? LivingEntity ?: run {
             logger.warn("Caster is not a living entity, aborting execution")
             return SkillResult.ERROR
         }
+
+        // 根据配置解析属性来源实体 (用于读取 AttributeContainer)
+        val sourceEntity = resolveSourceEntity(data) ?: run {
+            logger.warn("Failed to resolve attribute source entity (source=$attributeSource), aborting execution")
+            return SkillResult.ERROR
+        }
+
         val damageSource = when (casterEntity) {
             is Player -> KoishDamageSources.playerAttack(casterEntity)
             else -> KoishDamageSources.mobAttack(casterEntity)
         }
-        val attributeContainer = AttributeMapAccess.get(casterEntity).getOrNull() ?: run {
-            logger.warn("No AttributeMap found for caster $casterEntity, aborting execution")
+        val attributeContainer = AttributeMapAccess.get(sourceEntity).getOrNull() ?: run {
+            logger.warn("No AttributeMap found for source entity $sourceEntity (source=$attributeSource), aborting execution")
             return SkillResult.ERROR
         }
         val damageBundle = damageBundle(attributeContainer) {


### PR DESCRIPTION
## 调整 Mechanic: `koish_damage_attribute_map`

新增属性来源配置，支持从施法者的 parent（召唤者）链获取 AttributeContainer 来计算伤害，而不仅限于施法者自身。

### 新增参数

|名字|别名|类型|默认|说明|
|---|---|---|---|---|
|`source`|`src`|枚举 (`CASTER`, `PARENT`)|`CASTER`|属性来源。`CASTER` 使用施法者自身属性，`PARENT` 使用施法者的 parent（召唤者）属性|
|`source_depth`|`sd`|整数 (1~8)|`1`|当 `source=PARENT` 时，沿 parent 链向上查找的层数。`1` = 直接 parent，`2` = parent 的 parent，以此类推|

### 已有参数

|名字|别名|类型|默认|说明|
|---|---|---|---|---|
|`percent`|`p`|占位符双精度浮点数|`1.0`|最终伤害数值占面板数值的百分比。`1.0` 为 100%|
|`ignore_blocking`|`ib`|布尔值|`false`|是否无视格挡|
|`ignore_resistance`|`ir`|布尔值|`false`|是否无视抗性提升|
|`ignore_absorption`|`ia`|布尔值|`false`|是否无视伤害吸收|
|`knockback`|`kb`|布尔值|`true`|是否造成击退效果|

### 使用示例（部分）

```yaml
# 使用施法者自身属性 (默认行为, 与之前完全一致)
Skills:
- koish_damage_attribute_map{p=0.8} @target ~onAttack

# 使用施法者的 parent (召唤者) 的属性
Skills:
- koish_damage_attribute_map{source=PARENT;p=1.0} @target ~onAttack

# 使用施法者的 parent 的 parent 的属性 (往上2层)
Skills:
- koish_damage_attribute_map{src=PARENT;sd=2} @target ~onAttack
```

### 使用示例（完整）

[damage_attribute_map.zip](https://github.com/user-attachments/files/26658639/damage_attribute_map.zip)

### 设计说明

- **伤害归属不变**：`DamageSource`（击杀归属）始终基于 caster（施法者），只有属性来源可切换
- **递归查找 parent 链**：通过 `MythicBukkit.inst().mobManager.getActiveMob()` 将中间层 parent 解析为 `ActiveMob`，递归调用 `getParent()`
- **错误处理**：链中任何一层断裂（无 parent / 不是 LivingEntity / 不是 ActiveMob）都会输出精确到层级的 warn 日志并返回 `SkillResult.ERROR`

## 其他

- 更新 `AGENTS.md`：修正模块职责描述，区分 wakame-mixin Bridge 模式与 wakame-plugin 内部 handler 注入模式